### PR TITLE
fix units on weight and use 65535 instead of 65536

### DIFF
--- a/Pods/SwiftySensors/Sources/FitnessMachineService.swift
+++ b/Pods/SwiftySensors/Sources/FitnessMachineService.swift
@@ -135,7 +135,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
             }
             super.valueUpdated()
         }
@@ -184,7 +184,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()
@@ -206,7 +206,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()
@@ -228,7 +228,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()
@@ -250,7 +250,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()
@@ -272,7 +272,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()
@@ -318,7 +318,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()
@@ -340,7 +340,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()
@@ -421,7 +421,7 @@ open class FitnessMachineService: Service, ServiceProtocol {
         }
         
         override open func valueUpdated() {
-            if let value = cbCharacteristic.value {
+            if let _ = cbCharacteristic.value {
                 // TODO: deserialize value
             }
             super.valueUpdated()

--- a/Source/KineticService.swift
+++ b/Source/KineticService.swift
@@ -109,13 +109,8 @@ open class KineticService: Service, ServiceProtocol {
     
     public func writeSensorName(_ deviceName: String) {
         if let controlPoint = controlPoint {
-            do {
-                let bytes = KineticSerializer.setDeviceName(deviceName)
-                controlPoint.cbCharacteristic.write(Data(bytes: bytes), writeType: .withResponse)
-            } catch let error as NSError {
-                SensorManager.logSensorMessage?(error.localizedDescription)
-            }
+            let bytes = KineticSerializer.setDeviceName(deviceName)
+            controlPoint.cbCharacteristic.write(Data(bytes: bytes), writeType: .withResponse)
         }
     }
-    
 }

--- a/Source/WahooTrainerSerializer.swift
+++ b/Source/WahooTrainerSerializer.swift
@@ -68,10 +68,11 @@ open class WahooTrainerSerializer {
     }
     
     open static func seSimMode(weight: Float, rollingResistanceCoefficient: Float, windResistanceCoefficient: Float) -> [UInt8] {
+        // Weight units are Kg
         // TODO: Throw Error if weight, rrc or wrc are not within "sane" values
-        let weightN = UInt16(max(0, min(65.536, weight)) * 100)
-        let rrcN = UInt16(max(0, min(65.536, rollingResistanceCoefficient)) * 1000)
-        let wrcN = UInt16(max(0, min(65.536, windResistanceCoefficient)) * 1000)
+        let weightN = UInt16(max(0, min(655.35, weight)) * 100)
+        let rrcN = UInt16(max(0, min(65.535, rollingResistanceCoefficient)) * 1000)
+        let wrcN = UInt16(max(0, min(65.535, windResistanceCoefficient)) * 1000)
         return [
             WahooTrainerSerializer.OperationCode.setSimMode.rawValue,
             UInt8(weightN & 0xFF),
@@ -83,10 +84,9 @@ open class WahooTrainerSerializer {
         ]
     }
     
-    
     open static func setSimCRR(_ rollingResistanceCoefficient: Float) -> [UInt8] {
         // TODO: Throw Error if rrc is not within "sane" value range
-        let rrcN = UInt16(max(0, min(65.536, rollingResistanceCoefficient)) * 1000)
+        let rrcN = UInt16(max(0, min(65.535, rollingResistanceCoefficient)) * 1000)
         return [
             WahooTrainerSerializer.OperationCode.setSimCRR.rawValue,
             UInt8(rrcN & 0xFF),
@@ -94,10 +94,9 @@ open class WahooTrainerSerializer {
         ]
     }
     
-    
     open static func setSimWindResistance(_ windResistanceCoefficient: Float) -> [UInt8] {
         // TODO: Throw Error if wrc is not within "sane" value range
-        let wrcN = UInt16(max(0, min(65.536, windResistanceCoefficient)) * 1000)
+        let wrcN = UInt16(max(0, min(65.535, windResistanceCoefficient)) * 1000)
         return [
             WahooTrainerSerializer.OperationCode.setSimWindResistance.rawValue,
             UInt8(wrcN & 0xFF),
@@ -107,7 +106,7 @@ open class WahooTrainerSerializer {
     
     open static func setSimGrade(_ grade: Float) -> [UInt8] {
         // TODO: Throw Error if grade is not between -1 and 1
-        let norm = UInt16((min(1, max(-1, grade)) + 1.0) * 65536 / 2.0)
+        let norm = UInt16((min(1, max(-1, grade)) + 1.0) * 65535 / 2.0)
         return [
             WahooTrainerSerializer.OperationCode.setSimGrade.rawValue,
             UInt8(norm & 0xFF),
@@ -116,7 +115,7 @@ open class WahooTrainerSerializer {
     }
     
     open static func setSimWindSpeed(_ metersPerSecond: Float) -> [UInt8] {
-        let norm = UInt16((max(-32.768, min(32.768, metersPerSecond)) + 32.768) * 1000)
+        let norm = UInt16((max(-32.767, min(32.767, metersPerSecond)) + 32.767) * 1000)
         return [
             WahooTrainerSerializer.OperationCode.setSimWindSpeed.rawValue,
             UInt8(norm & 0xFF),
@@ -153,8 +152,6 @@ open class WahooTrainerSerializer {
                 SensorManager.logSensorMessage?("Success for operation: \(opCodeRaw)")
             }
         }
-        
         return nil
     }
-    
 }


### PR DESCRIPTION
Fixed some value conversions and build warnings

To test, create a playground in Xcode and test some values for these serializers and make sure values look right, especially at or outside of limits. 


let weight = 85.0
let rollingResistanceCoefficient = 0.004
let windResistanceCoefficient = 0.60

let weightN = UInt16(max(0, min(65.536, weight)) * 100)
let rrcN = UInt16(max(0, min(65.536, rollingResistanceCoefficient)) * 1000)
let wrcN = UInt16(max(0, min(65.536, windResistanceCoefficient)) * 1000)

    UInt8(weightN & 0xFF)
    UInt8(weightN >> 8 & 0xFF)
    UInt8(rrcN & 0xFF)
    UInt8(rrcN >> 8 & 0xFF)
    UInt8(wrcN & 0xFF)
    UInt8(wrcN >> 8 & 0xFF)

let metersPerSecond = -32.768
norm = UInt16((max(-32.767, min(32.767, metersPerSecond)) + 32.767) * 1000)

let resistance = 0.0

norm = UInt16((1 - resistance) * 16383)


var fpScale = resistance
// clamp the scale between 0 and 1.
if ( fpScale < 0 ) {fpScale = 0}
if ( fpScale > 1 ) {fpScale = 1}
//
// invert the scale to account for active low.
fpScale = 1.0 - fpScale;
//
// convert the scale to 14-bit integer.
let usScale = (fpScale * 0x3FFF);
 